### PR TITLE
Document subtitle editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 -   📂 Batch transcribe multiple files!
 -   📝 Support `SRT`, `VTT`, `TXT`, `HTML`, `PDF`, `JSON`, `DOCX` formats
 -   👀 Realtime preview
+-   ✏️ Built-in subtitle editor with video preview and quick timestamp controls
 -   ✨ Summarize transcripts: Get quick, multilingual summaries using the Claude API
 -   🧠 Ollama support: Do local AI analysis and batch summaries with Ollama
 -   🌐 Translate to English from any language
@@ -97,6 +98,7 @@ In addition you can add translation to [Vibe website](https://thewh1teagle.githu
 # Docs 📄
 
 see [Vibe Docs](https://github.com/thewh1teagle/vibe/tree/main/docs)
+Check the [Subtitle Editor guide](docs/editor.md) to learn how to refine captions.
 
 # I want to know more!
 
@@ -123,3 +125,4 @@ Thanks for [openai.com](https://openai.com/) for their amazing [Whisper model](h
 Thanks for [github.com](https://github.com/) for their support in open source projects, providing infastructure completely free.
 
 And for all the amazing open source frameworks and libraries which this project uses...
+Forked from Vibe, borrowed from SubtitleEditor and stitched together by Codex with Daniel Ramos's EchoSystems creative line and guidance.

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,18 @@
+# Subtitle Editor
+
+Vibe features a built-in subtitle editor for precise control over your transcripts.
+
+## Navigation
+
+1. After transcribing a file on the home page, select **Edit Subtitles** to open the editor.
+2. You can also go to **Convert**, load an existing subtitle and click **Edit in Editor**.
+
+## Editor Features
+
+- Video preview for adjusting times
+- Quick buttons to set start/end to the current video time
+- Insert segments above or below
+- Split or delete segments
+- Optional autosave, or press **Ctrl+S** to save
+- Supports export to `srt`, `vtt`, `json`, `txt` and `docx`
+- Undo with **Ctrl+Z**


### PR DESCRIPTION
## Summary
- document new subtitle editor in README and docs
- link to editor docs from README
- credit Codex per instructions

## Testing
- `cargo test` *(fails: gobject-2.0.pc missing)*
- `npm run lint` in desktop *(fails: Cannot find package 'globals')*
- `npm run lint` in landing *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b63c72748324967c050c018934a0