### PR TITLE
Add language selector to landing page

### DIFF
--- a/landing/src/components/Nav.svelte
+++ b/landing/src/components/Nav.svelte
@@ -3,8 +3,10 @@
 	import Discord from '~/icons/Discord.svelte'
 	import Github from '~/icons/Github.svelte'
 	import Logo from '~/icons/Logo.svelte'
-	import { i18n } from '~/lib/i18n'
-	const t = $i18n.t
+import { i18n, supportedLanguages } from '~/lib/i18n'
+const t = $i18n.t
+
+const languages = Object.entries(supportedLanguages)
 </script>
 
 <div class="navbar bg-base-100 lg:flex lg:max-w-[1065px] mt-3 m-auto">
@@ -15,9 +17,21 @@
 		</a>
 	</div>
 	<!-- links -->
-	<ul class="flex-none menu menu-horizontal px-1 gap-4" dir="ltr">
-		<a href={`https://github.com/thewh1teagle/vibe`} target="_blank">
-			<Github width="28" height="28" />
-		</a>
-	</ul>
+       <ul class="flex-none menu menu-horizontal px-1 gap-4" dir="ltr">
+               <li class="flex items-center">
+                       <label class="sr-only">{t('language')}</label>
+                       <select
+                               class="select select-bordered select-sm"
+                               on:change={(e) => i18n.changeLanguage(e.target.value)}
+                               bind:value={$i18n.language}>
+                               <option value="">{t('select-language')}</option>
+                               {#each languages as [code, name]}
+                                       <option value={code}>{name}</option>
+                               {/each}
+                       </select>
+               </li>
+               <a href={`https://github.com/thewh1teagle/vibe`} target="_blank">
+                       <Github width="28" height="28" />
+               </a>
+       </ul>
 </div>

--- a/landing/src/lib/i18n.ts
+++ b/landing/src/lib/i18n.ts
@@ -3,6 +3,20 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
 import { createI18nStore } from 'svelte-i18next'
 
+export const supportedLanguages: { [key: string]: string } = {
+       'en-US': 'English',
+       'he-IL': '\u05e2\u05d1\u05e8\u05d9\u05ea',
+       'fr-FR': 'Français',
+       'pl-PL': 'polski',
+       'pt-BR': 'Português',
+       'zh-CN': '\u4e2d\u6587',
+       'zh-HK': '\u4e2d\u6587 (HK)',
+       'no-NO': 'norsk',
+       'ru-RU': '\u0420\u0443\u0441\u0441\u043a\u0438\u0439',
+       'es-MX': 'Español',
+       'ko-KR': '\ud55c\uad6d\uc5b4',
+}
+
 i18next
 	.use(HttpBackend)
 	.use(LanguageDetector)
@@ -15,17 +29,7 @@ i18next
 		},
 		fallbackLng: 'en-US',
 		// lng: 'en', // testing in dev mode
-		supportedLngs: [
-			'en-US',
-			'he-IL',
-			'fr-FR',
-			'pl-PL',
-			'pt-BR',
-			'zh-CN',
-			'zh-HK',
-			'no-NO',
-			'ru-RU',
-		],
+               supportedLngs: Object.keys(supportedLanguages),
 		ns: 'translation',
 		backend: {
 			loadPath: 'locales/{{lng}}.json',

--- a/landing/static/locales/en-US.json
+++ b/landing/static/locales/en-US.json
@@ -15,10 +15,12 @@
 	"intel": "Intel Chip",
 	"open-logs-folder": "Open Logs Folder",
 	"privacy-policy": "Privacy Policy",
-	"star-on-github": "Star On Github",
-	"support-project": "Support Vibe!",
-	"support-vibe": "Support Vibe",
-	"support-while-you-wait": "While you wait, consider supporting the Vibe project to help us grow!",
-	"title": "Transcribe. on Your Own.",
-	"your-download-is-starting": "Your download is starting..."
+        "star-on-github": "Star On Github",
+        "support-project": "Support Vibe!",
+        "support-vibe": "Support Vibe",
+        "support-while-you-wait": "While you wait, consider supporting the Vibe project to help us grow!",
+        "language": "Language",
+        "select-language": "Select Language",
+        "title": "Transcribe. on Your Own.",
+        "your-download-is-starting": "Your download is starting..."
 }

--- a/landing/static/locales/es-MX.json
+++ b/landing/static/locales/es-MX.json
@@ -19,6 +19,8 @@
 	"support-project": "¡Apoya la vibra!",
 	"support-vibe": "Apoya a Vibe",
 	"support-while-you-wait": "Mientras espera, considere apoyar el proyecto Vibe para ayudarnos a crecer.",
+        "language": "Idioma",
+        "select-language": "Seleccionar Idioma",
 	"title": "Transcribe. Por ti mismo(a).",
 	"your-download-is-starting": "Tu descarga está comenzando..."
 }

--- a/landing/static/locales/fr-FR.json
+++ b/landing/static/locales/fr-FR.json
@@ -19,6 +19,8 @@
 	"support-project": "Soutenez Vibe !",
 	"support-vibe": "Ambiance de soutien",
 	"support-while-you-wait": "En attendant, pensez à soutenir le projet Vibe pour nous aider à grandir !",
+        "language": "Langue",
+        "select-language": "Sélectionner une langue",
 	"title": "Transcription audio locale.",
 	"your-download-is-starting": "Votre téléchargement commence..."
 }

--- a/landing/static/locales/he-IL.json
+++ b/landing/static/locales/he-IL.json
@@ -19,6 +19,8 @@
 	"support-project": "תמכו ב-Vibe!",
 	"support-vibe": "תמיכה בVibe",
 	"support-while-you-wait": "בזמן שאתה מחכה, שקול לתמוך בפרויקט Vibe כדי לעזור לנו לצמוח!",
+        "language": "שפה",
+        "select-language": "בחר שפה",
 	"title": "תמלל קבצי אודיו או וידאו!",
 	"your-download-is-starting": "ההורדה שלך מתחילה..."
 }

--- a/landing/static/locales/ko-KR.json
+++ b/landing/static/locales/ko-KR.json
@@ -19,6 +19,8 @@
     "support-project": "Vibe 지원하기!",
     "support-vibe": "Vibe 지원하기",
     "support-while-you-wait": "기다리는 동안, Vibe 프로젝트를 후원하여 저희의 성장을 도와주는 것을 고려해 주세요!",
+        "language": "언어",
+        "select-language": "언어 선택",
     "title": "받아쓰기. 나의 기기에서.",
     "your-download-is-starting": "다운로드가 시작되었습니다..."
 }

--- a/landing/static/locales/no-NO.json
+++ b/landing/static/locales/no-NO.json
@@ -19,6 +19,8 @@
 	"support-project": "Støtt Vibe!",
 	"support-vibe": "Støtt Vibe",
 	"support-while-you-wait": "Mens du venter, vurder å støtte Vibe-prosjektet for å hjelpe oss med å vokse!",
+        "language": "Språk",
+        "select-language": "Velg språk",
 	"title": "Transkriber. På din egen måte.",
 	"your-download-is-starting": "Nedlastingen din starter..."
 }

--- a/landing/static/locales/pl-PL.json
+++ b/landing/static/locales/pl-PL.json
@@ -19,6 +19,8 @@
 	"support-project": "Wspieraj Vibe!",
 	"support-vibe": "Wspomóż Vibe",
 	"support-while-you-wait": "Czekając, rozważ wsparcie projektu Vibe, który pomoże nam się rozwijać!",
+        "language": "Język",
+        "select-language": "Wybierz język",
 	"title": "Transkrybuj. po swojemu.",
 	"your-download-is-starting": "Rozpoczyna się pobieranie..."
 }

--- a/landing/static/locales/pt-BR.json
+++ b/landing/static/locales/pt-BR.json
@@ -19,6 +19,8 @@
 	"support-project": "Apoie a Vibe!",
 	"support-vibe": "Apoiar Vibe",
 	"support-while-you-wait": "Enquanto espera, considere apoiar o projeto Vibe para nos ajudar a crescer!",
+        "language": "Idioma",
+        "select-language": "Selecione o idioma",
 	"title": "Transcreva. por conta própria.",
 	"your-download-is-starting": "Seu download está começando..."
 }

--- a/landing/static/locales/ru-RU.json
+++ b/landing/static/locales/ru-RU.json
@@ -19,6 +19,8 @@
 	"support-project": "Поддержать Vibe!",
 	"support-vibe": "Поддержать Vibe",
 	"support-while-you-wait": "Пока вы ждете, возможно вы захотите поддержать проект Vibe, это поможет нам развивать его дальше!",
+        "language": "Язык",
+        "select-language": "Выбрать язык",
 	"title": "Транскрибируйте сами, без посторонней помощи",
 	"your-download-is-starting": "Загрузка начинается..."
 }

--- a/landing/static/locales/zh-CN.json
+++ b/landing/static/locales/zh-CN.json
@@ -19,6 +19,8 @@
 	"support-project": "支持 Vibe！",
 	"support-vibe": "支持 Vibe",
 	"support-while-you-wait": "等待时，不妨考虑支持 Vibe 项目，帮助我们成长！",
+        "language": "语言",
+        "select-language": "选择语言",
 	"title": "自主转录。",
 	"your-download-is-starting": "您的下载即将开始..."
 }

--- a/landing/static/locales/zh-HK.json
+++ b/landing/static/locales/zh-HK.json
@@ -19,6 +19,8 @@
 	"support-project": "支持 Vibe！",
 	"support-vibe": "支持 Vibe",
 	"support-while-you-wait": "等待時，不妨考慮支持 Vibe 項目，幫助我們成長！",
+        "language": "語言",
+        "select-language": "選擇語言",
 	"title": "自主轉錄。",
 	"your-download-is-starting": "您的下載即將開始..."
 }


### PR DESCRIPTION
## Summary
- add explicit supportedLanguages to landing i18n
- include missing languages in supportedLngs
- add language picker UI in Nav
- translate new strings across website locales

## Testing
- `npm run lint` (fails: Cannot find package 'globals')
- `cargo test` (fails: system library `glib-2.0` not found)


------
https://chatgpt.com/codex/tasks/task_e_6864b9830f90832481c8d2bc966fab70