### PR TITLE
Fix subtitle history snapshots

### DIFF
--- a/desktop/src/components/SubtitleEditor.tsx
+++ b/desktop/src/components/SubtitleEditor.tsx
@@ -176,7 +176,8 @@ export default function SubtitleEditor({ transcript, setTranscript, videoSrc, au
 
     function updateSegments(newSegs: Segment[]) {
         setSegments(newSegs)
-        historyRef.current.push(newSegs)
+        // Store a snapshot to avoid mutating history entries when segments change
+        historyRef.current.push(newSegs.map((s) => ({ ...s })))
     }
 
     async function saveToFile() {
@@ -263,7 +264,8 @@ export default function SubtitleEditor({ transcript, setTranscript, videoSrc, au
     }, [segments])
 
     useEffect(() => {
-        historyRef.current = [segments]
+        // Initialize history with a snapshot of the initial segments
+        historyRef.current = [segments.map((s) => ({ ...s }))]
     }, [])
 
     return (


### PR DESCRIPTION
## Summary
- store deep copies of subtitle segments for undo history
- initialize history with first segment snapshot

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `cargo test` *(fails: tls connection init failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_689574a851e48324994ce04c1e0d10dc